### PR TITLE
fix: postinstall script doesn't produce json on windows

### DIFF
--- a/npm/a/package.json
+++ b/npm/a/package.json
@@ -3,12 +3,12 @@
   "license": "Apache-2.0",
   "private": false,
   "repository": "git://github.com/aspect-build/test-packages.git",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "index.js",
   "bin": { "bin_a": "bin.js" },
   "dependencies": {
-    "@aspect-test/b": "5.0.0",
-    "@aspect-test/c": "1.0.0",
+    "@aspect-test/b": "5.0.1",
+    "@aspect-test/c": "2.0.1",
     "@aspect-test/d": "2.0.0"
   }
 }

--- a/npm/b/package.json
+++ b/npm/b/package.json
@@ -3,12 +3,12 @@
   "license": "Apache-2.0",
   "private": false,
   "repository": "git://github.com/aspect-build/test-packages.git",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "main": "index.js",
   "bin": { "bin_b": "bin.js" },
   "dependencies": {
-    "@aspect-test/a": "5.0.0",
-    "@aspect-test/c": "2.0.0",
+    "@aspect-test/a": "5.0.1",
+    "@aspect-test/c": "2.0.1",
     "@aspect-test/d": "2.0.0"
   }
 }

--- a/npm/c/package.json
+++ b/npm/c/package.json
@@ -3,10 +3,10 @@
   "license": "Apache-2.0",
   "private": false,
   "repository": "git://github.com/aspect-build/test-packages.git",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.js",
   "bin": { "bin_c": "bin.js" },
   "scripts": {
-    "postinstall": "echo \"{\\\"answer\\\":\\\"42*\\\"}\" > data.json"
+    "postinstall": "echo '{\"answer\":\"42*\"}' > data.json"
   }
 }


### PR DESCRIPTION
Needed for a windows fix in rules_js. On windows this produces a string containing json rather than json.