### PR TITLE
fix: make postinstall script cross-platform

### DIFF
--- a/npm/a/package.json
+++ b/npm/a/package.json
@@ -3,12 +3,12 @@
   "license": "Apache-2.0",
   "private": false,
   "repository": "git://github.com/aspect-build/test-packages.git",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "main": "index.js",
   "bin": { "bin_a": "bin.js" },
   "dependencies": {
-    "@aspect-test/b": "5.0.1",
-    "@aspect-test/c": "2.0.1",
+    "@aspect-test/b": "5.0.2",
+    "@aspect-test/c": "2.0.2",
     "@aspect-test/d": "2.0.0"
   }
 }

--- a/npm/b/package.json
+++ b/npm/b/package.json
@@ -3,12 +3,12 @@
   "license": "Apache-2.0",
   "private": false,
   "repository": "git://github.com/aspect-build/test-packages.git",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "main": "index.js",
   "bin": { "bin_b": "bin.js" },
   "dependencies": {
-    "@aspect-test/a": "5.0.1",
-    "@aspect-test/c": "2.0.1",
+    "@aspect-test/a": "5.0.2",
+    "@aspect-test/c": "2.0.2",
     "@aspect-test/d": "2.0.0"
   }
 }

--- a/npm/c/package.json
+++ b/npm/c/package.json
@@ -3,10 +3,10 @@
   "license": "Apache-2.0",
   "private": false,
   "repository": "git://github.com/aspect-build/test-packages.git",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "main": "index.js",
   "bin": { "bin_c": "bin.js" },
   "scripts": {
-    "postinstall": "echo '{\"answer\":\"42*\"}' > data.json"
+    "postinstall": "bash -c 'echo {\\\"answer\\\":\\\"42*\\\"}' > data.json"
   }
 }


### PR DESCRIPTION
I made the mistake on the last PR of testing the script in each platform's console but not via `npm install`. This should work now.